### PR TITLE
fix: add US phone support and default to +1 on user registration

### DIFF
--- a/src/components/internal/Auth/UserRegister/UserRegistrationForm.tsx
+++ b/src/components/internal/Auth/UserRegister/UserRegistrationForm.tsx
@@ -24,7 +24,7 @@ type UserFormData = z.infer<typeof userSchema>;
 const UserRegistrationForm = () => {
     const [loading, setLoading] = useState(false);
     const { toast } = useToast();
-    const [countryCode, setCountryCode] = useState('+91');
+    const [countryCode, setCountryCode] = useState('+1');
     const navigate = useNavigate();
     const [referralCodeDigits, setReferralCodeDigits] = useState("");
 
@@ -144,8 +144,8 @@ const UserRegistrationForm = () => {
                 <div>
                     <label className="block text-sm font-medium text-gray-600 mb-1">Phone Number*</label>
                     <PhoneInput
-                        country="in"
-                        onlyCountries={['in']}
+                        country="us"
+                        onlyCountries={['in', 'us']}
                         onChange={handlePhoneChange}
                         inputStyle={{
                             width: "100%",


### PR DESCRIPTION
## Summary
- Added US (+1) as a supported country on the user registration phone input
- Changed the default country from India (+91) to United States (+1)
- Both India and US numbers are now accepted

## Test plan
- [ ] Open `/user/register` on the website
- [ ] Confirm phone input defaults to 🇺🇸 +1
- [ ] Switch to 🇮🇳 +91 and verify India numbers still work
- [ ] Register with a US number and verify submission succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)