### PR TITLE
fix: Reports UI polish — ring font size + Download button label

### DIFF
--- a/src/components/internal/results/Results.tsx
+++ b/src/components/internal/results/Results.tsx
@@ -105,8 +105,9 @@ export default function Results() {
           <div className="px-2.5 sm:px-0 mb-5">
             <div className="rounded-2xl p-5 flex items-center justify-between" style={{ background: 'linear-gradient(135deg, #704180, #8B2D6C)' }}>
               <div className="flex items-center gap-3">
-                <div className="w-10 h-10 rounded-xl flex items-center justify-center" style={{ background: 'rgba(255,255,255,0.2)' }}>
-                  <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>
+                {/* assessment_rounded icon — square with bar chart bars, matches app */}
+              <div className="w-10 h-10 rounded-xl flex items-center justify-center" style={{ background: 'rgba(255,255,255,0.2)' }}>
+                <svg className="w-5 h-5" fill="white" viewBox="0 0 24 24"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14H7v-2h5v2zm5-4H7v-2h10v2zm0-4H7V7h10v2z"/></svg>
                 </div>
                 <div>
                   <p className="text-white font-semibold text-sm">{selected.cycle ? `Assessment ${selected.cycle}` : 'Assessment Cycle'}</p>
@@ -136,7 +137,7 @@ export default function Results() {
                       strokeDashoffset={circ * (1 - avg / 100)}
                       strokeLinecap="round" transform="rotate(-90 60 60)"
                       style={{ transition: 'stroke-dashoffset 1s ease-out' }} />
-                    <text x="50%" y="50%" textAnchor="middle" dy=".35em" fontSize="22" fill="white" fontWeight="bold">{avg}</text>
+                    <text x="50%" y="50%" textAnchor="middle" dy=".35em" fontSize="32" fill="white" fontWeight="bold">{avg}</text>
                   </svg>
                 </div>
                 <div className="flex-1 min-w-0">
@@ -189,7 +190,7 @@ export default function Results() {
               style={{ background: 'linear-gradient(135deg, #704180, #8B2D6C)' }}
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
-              Short Report
+              Download full report
             </button>
           ) : (selected?.testsCompleted ?? 0) > 0 && (
             /* Report generating indicator — matches app's orange spinner */

--- a/src/components/internal/results/Results.tsx
+++ b/src/components/internal/results/Results.tsx
@@ -120,30 +120,37 @@ export default function Results() {
           </div>
         )}
 
-        {/* Overall wellness + tests completed */}
-        <div className="px-2.5 sm:px-0">
-          {barData.length > 0 && (() => {
-            const avg = Math.round(barData.reduce((s, d) => s + d.value, 0) / barData.length);
-            return (
-              <div className="flex items-center gap-4 mb-5 p-4 rounded-2xl" style={{ background: '#F6F2F7' }}>
-                <div className="relative flex-shrink-0" style={{ width: 64, height: 64 }}>
-                  <svg width="64" height="64" viewBox="0 0 64 64">
-                    <circle cx="32" cy="32" r="26" stroke="#E5E0EA" strokeWidth="6" fill="none" />
-                    <circle cx="32" cy="32" r="26" stroke="#704180" strokeWidth="6" fill="none"
-                      strokeDasharray={2 * Math.PI * 26}
-                      strokeDashoffset={2 * Math.PI * 26 * (1 - avg / 100)}
-                      strokeLinecap="round" transform="rotate(-90 32 32)" />
-                    <text x="50%" y="50%" textAnchor="middle" dy=".35em" fontSize="13" fill="#704180" fontWeight="bold">{avg}</text>
+        {/* Overall Wellness card — matches app: purple gradient, large ring left, text right */}
+        {barData.length > 0 && (() => {
+          const avg = Math.round(barData.reduce((s, d) => s + d.value, 0) / barData.length);
+          const r = 46; const circ = 2 * Math.PI * r;
+          return (
+            <div className="px-2.5 sm:px-0 mb-5">
+              <div className="rounded-2xl p-5 flex items-center gap-5" style={{ background: 'linear-gradient(135deg, #704180, #8B2D6C)' }}>
+                {/* Circular progress ring — 120×120 matching app */}
+                <div className="relative flex-shrink-0" style={{ width: 120, height: 120 }}>
+                  <svg width="120" height="120" viewBox="0 0 120 120">
+                    <circle cx="60" cy="60" r={r} stroke="rgba(255,255,255,0.2)" strokeWidth="8" fill="none" />
+                    <circle cx="60" cy="60" r={r} stroke="white" strokeWidth="8" fill="none"
+                      strokeDasharray={circ}
+                      strokeDashoffset={circ * (1 - avg / 100)}
+                      strokeLinecap="round" transform="rotate(-90 60 60)"
+                      style={{ transition: 'stroke-dashoffset 1s ease-out' }} />
+                    <text x="50%" y="50%" textAnchor="middle" dy=".35em" fontSize="22" fill="white" fontWeight="bold">{avg}</text>
                   </svg>
                 </div>
-                <div>
-                  <p className="text-xs text-[#808080] font-medium uppercase tracking-wide">Overall Wellness</p>
-                  <p className="text-lg font-bold text-black mt-0.5">{avg}%</p>
-                  <p className="text-xs text-[#808080]">Normalized across all 5 scales</p>
+                <div className="flex-1 min-w-0">
+                  <p className="text-white/70 text-[11px] font-semibold tracking-wider uppercase mb-1">Overall Wellness</p>
+                  <p className="text-white text-2xl font-bold font-['Urbanist']">{avg}%</p>
+                  <p className="text-white/70 text-xs mt-1">Normalized across all 5 scales</p>
                 </div>
               </div>
-            );
-          })()}
+            </div>
+          );
+        })()}
+
+        {/* Tests completed */}
+        <div className="px-2.5 sm:px-0">
           <p className="text-sm text-[#6C7278]">{selected?.testsCompleted ?? 0} of 5 tests completed</p>
           <div className="flex gap-2 mt-2.5 mb-[30px]">
             {[0, 1, 2, 3, 4].map(i => (
@@ -178,10 +185,10 @@ export default function Results() {
                   window.open(selected.reportView, '_blank');
                 }
               }}
-              className="flex items-center justify-center gap-2 w-full py-3 rounded-full text-white font-medium text-base hover:opacity-90 transition"
-              style={{ background: '#704180' }}
+              className="flex items-center justify-center gap-2 w-full py-4 rounded-2xl text-white font-bold text-base hover:opacity-90 transition"
+              style={{ background: 'linear-gradient(135deg, #704180, #8B2D6C)' }}
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
               Short Report
             </button>
           ) : (selected?.testsCompleted ?? 0) > 0 && (

--- a/src/components/internal/results/Results.tsx
+++ b/src/components/internal/results/Results.tsx
@@ -240,45 +240,125 @@ export default function Results() {
   );
 }
 
-// ── Animated Bar Chart ──
-function AnimatedBarChart({ data, animated }: { data: { title: string; value: number }[]; animated: boolean }) {
-  const chartH = 220;
+// ── Wellness Bar Chart — matches app WellnessBarChart exactly ──
+const WELLNESS_KEYS = ['Sleep', 'Nutrition', 'Emotional'];
+const ANXIETY_KEYS  = ['GAD-7', 'PHQ-9'];
+
+function wellnessColor(v: number) {
+  if (v >= 70) return '#00C48C';
+  if (v >= 50) return '#F5A623';
+  return '#FF5C5C';
+}
+function wellnessLabel(v: number) {
+  if (v >= 70) return 'Thriving';
+  if (v >= 50) return 'Fair';
+  return 'Needs care';
+}
+function severityColor(v: number) {
+  if (v <= 20) return '#00C48C';
+  if (v <= 45) return '#F5A623';
+  if (v <= 70) return '#FF8C00';
+  return '#FF5C5C';
+}
+function severityLabel(v: number) {
+  if (v <= 20) return 'Minimal';
+  if (v <= 45) return 'Mild';
+  if (v <= 70) return 'Moderate';
+  return 'Severe';
+}
+function findKey(raw: string, keys: string[]) {
+  const n = raw.toLowerCase().replace(/-/g,'').replace(/_/g,'');
+  return keys.find(k => k.toLowerCase().replace(/-/g,'').replace(/_/g,'') === n
+    || raw.toLowerCase().includes(k.toLowerCase()) || k.toLowerCase().includes(raw.toLowerCase()));
+}
+
+function BarSection({ title, note, legend, entries, inverted, animated }:
+  { title: string; note: string; legend: {label:string; color:string}[];
+    entries: {key:string; value:number}[]; inverted: boolean; animated: boolean }) {
+  const BAR_H = 140;
   return (
-    <div>
-      <div className="flex">
-        <div className="flex flex-col justify-between pr-2 text-[10px] text-black font-normal w-10 text-right" style={{ height: chartH }}>
-          {[100, 75, 50, 25, 0].map(v => <span key={v}>{v.toFixed(1)}</span>)}
-        </div>
-        <div className="flex-1 relative">
-          <div className="absolute inset-0 flex flex-col justify-between pointer-events-none">
-            {[0, 1, 2, 3, 4].map(i => <div key={i} className="border-b border-blue-200/30" />)}
-          </div>
-          <div className="flex items-end gap-1.5 sm:gap-2 px-1 relative z-10" style={{ height: chartH }}>
-            {data.map((bar, i) => {
-              const pct = Math.max((bar.value / 100), 0.01);
-              return (
-                <div key={bar.title} className="flex-1 flex justify-center items-end" style={{ height: '100%' }}>
-                  <div className="w-full max-w-[18px] sm:max-w-[22px] rounded-t-full transition-all ease-out"
-                    style={{
-                      height: animated ? `${pct * 100}%` : '1px',
-                      background: 'linear-gradient(to bottom, #704180, #8B2D6C)',
-                      transitionDuration: `${500 + i * 100}ms`,
-                    }}
-                  />
-                </div>
-              );
-            })}
-          </div>
-          <div className="border-t border-[#A3A3A3]" />
-        </div>
+    <div className="mb-5">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-sm font-bold text-black">{title}</span>
+        <span className="text-[11px] text-gray-400">{note}</span>
       </div>
-      <div className="flex ml-10 mt-2">
-        {data.map(bar => (
-          <div key={bar.title} className="flex-1 text-center text-[9px] sm:text-[10px] text-black leading-tight px-0.5">
-            {bar.title.replace('Assessment', '').trim().split(' ').map((word, wi) => <span key={wi}>{word}<br/></span>)}
+      <div className="flex flex-wrap gap-x-3 gap-y-1 mb-3">
+        {legend.map(l => (
+          <div key={l.label} className="flex items-center gap-1.5">
+            <div className="w-2 h-2 rounded-full" style={{ background: l.color }} />
+            <span className="text-[11px] text-gray-500">{l.label}</span>
           </div>
         ))}
       </div>
+      {/* Chart card — white with shadow like app */}
+      <div className="rounded-2xl p-4" style={{ background: 'white', boxShadow: '0 2px 12px rgba(0,0,0,0.06)' }}>
+        <div className="flex" style={{ height: BAR_H + 24 }}>
+          {/* Y-axis */}
+          <div className="flex flex-col justify-between pr-2 text-[10px] text-gray-400 text-right" style={{ width: 36, height: BAR_H }}>
+            {['100%','75%','50%','25%','0%'].map(l => <span key={l}>{l}</span>)}
+          </div>
+          {/* Bars */}
+          <div className="flex-1 relative" style={{ height: BAR_H }}>
+            {/* Grid lines */}
+            <div className="absolute inset-0 flex flex-col justify-between pointer-events-none">
+              {[0,1,2,3,4].map(i => <div key={i} className="border-b" style={{ borderColor:'rgba(0,0,0,0.07)' }} />)}
+            </div>
+            <div className="absolute inset-0 flex items-end justify-around px-1">
+              {entries.map((e, i) => {
+                const v = Math.max(e.value, 0);
+                const color = inverted ? severityColor(v) : wellnessColor(v);
+                const lbl   = inverted ? severityLabel(v)  : wellnessLabel(v);
+                const barPx = Math.max((v / 100) * BAR_H, 4);
+                return (
+                  <div key={e.key} className="flex flex-col items-center justify-end" style={{ width: 48 }}>
+                    <span className="text-[9px] font-bold mb-1 leading-none" style={{ color }}>{lbl}</span>
+                    <div className="rounded-t-lg transition-all ease-out"
+                      style={{
+                        width: 36, height: animated ? barPx : 2,
+                        background: color,
+                        boxShadow: `0 2px 4px ${color}44`,
+                        transitionDuration: `${600 + i * 120}ms`,
+                      }} />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+        {/* Metric name labels */}
+        <div className="flex justify-around mt-2 pl-10">
+          {entries.map(e => (
+            <div key={e.key} className="text-center text-[10px] font-semibold text-gray-600 leading-tight" style={{ width: 48 }}>
+              {(e.key === 'Emotional' ? 'Emotional\nWellness' : e.key).split('\n').map((w, wi) => <span key={wi}>{w}<br/></span>)}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AnimatedBarChart({ data, animated }: { data: { title: string; value: number }[]; animated: boolean }) {
+  const wellnessEntries = WELLNESS_KEYS
+    .map(k => { const d = data.find(x => findKey(x.title, [k])); return { key: k, value: d?.value ?? 0 }; })
+    .filter(e => e.value > 0);
+  const anxietyEntries  = ANXIETY_KEYS
+    .map(k => { const d = data.find(x => findKey(x.title, [k])); return { key: k, value: d?.value ?? 0 }; })
+    .filter(e => e.value > 0);
+
+  return (
+    <div>
+      {wellnessEntries.length > 0 && (
+        <BarSection title="Wellness Scores" note="Higher = healthier"
+          legend={[{label:'Thriving',color:'#00C48C'},{label:'Fair',color:'#F5A623'},{label:'Needs care',color:'#FF5C5C'}]}
+          entries={wellnessEntries} inverted={false} animated={animated} />
+      )}
+      {anxietyEntries.length > 0 && (
+        <BarSection title="Depression & Anxiety" note="Higher = more severe"
+          legend={[{label:'Minimal',color:'#00C48C'},{label:'Mild',color:'#F5A623'},{label:'Moderate',color:'#FF8C00'},{label:'Severe',color:'#FF5C5C'}]}
+          entries={anxietyEntries} inverted={true} animated={animated} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Ring number in Overall Wellness card: font size 22 → 32 to match app's large bold display
- Button label: "Short Report" → "Download full report" matching app exactly
- Button already had the correct download arrow icon from previous commit

## Test plan
- [ ] Navigate to Results page with completed tests
- [ ] Verify the Overall Wellness ring shows a large bold number (not small)
- [ ] Verify the button reads "Download full report" with download arrow icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)